### PR TITLE
Trim only a single leading space from comment text

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -168,11 +168,11 @@ class Generator {
     let groupedComments = []
     for (const comment of leadingComments) {
       if (lastComment && lastComment.loc.end.line === comment.loc.start.line - 1) {
-        lastComment.value += '\n' + comment.value.trim()
+        lastComment.value += '\n' + comment.value.replace(/^\s/, '')
         lastComment.loc.end = comment.loc.end
       } else {
         lastComment = {
-          value: comment.value.trim(),
+          value: comment.value.replace(/^\s/, ''),
           loc: comment.loc
         }
         groupedComments.push(lastComment)


### PR DESCRIPTION
Calling `comment.value.trim()` eliminates _all_ leading and trailing whitespace in documentation comments, including ones within code blocks:

<img width="659" alt="before" src="https://user-images.githubusercontent.com/17565/28985015-9a2363ee-792e-11e7-90be-842854171934.png">

I've altered this to eat only a single leading whitespace, to handle the common case of:

```js
  // Text text text
  //
  // ```js
  // function leftAligned() {
  //   console.log('yep')
  // }
  // ```
```

<img width="637" alt="after" src="https://user-images.githubusercontent.com/17565/28985134-1e4d8d0c-792f-11e7-858b-d715fb03fb94.png">

With this change in place, we should also handle nested bullet lists properly for #4.
