### PR TITLE
Generate docs for public properties assigned in constructors

### DIFF
--- a/test/generate-test.js
+++ b/test/generate-test.js
@@ -235,6 +235,56 @@ describe('generate(code)', function () {
     assertMatchingObjects(result, donnaResult, [4, 2], [4, 10])
   })
 
+  it('handles public instance properties', function () {
+    const result = generate(dedent`
+      // Public: A useful class
+      class Thing {
+        constructor (params) {
+
+          // Public: An instance of A
+          this.a = params.a || new A()
+
+          if (params.b) {
+
+            // Public: An instance of B
+            this.b = params.b || new B()
+          }
+        }
+      }
+    `)
+
+    assert.deepEqual(result.objects['1']['0'], {
+      type: 'class',
+      name: 'Thing',
+      superClass: null,
+      doc: 'Public: A useful class',
+      range: [[1, 0], [13, 1]],
+      bindingType: undefined,
+      classProperties: [],
+      prototypeProperties: [
+        [2, 2],
+        [5, 4],
+        [10, 6]
+      ]
+    })
+
+    assert.deepEqual(result.objects['5']['4'], {
+      name: 'a',
+      doc: 'Public: An instance of A',
+      range: [[5, 4], [5, 32]],
+      bindingType: 'prototypeProperty',
+      type: 'primitive'
+    })
+
+    assert.deepEqual(result.objects['10']['6'], {
+      name: 'b',
+      doc: 'Public: An instance of B',
+      range: [[10, 6], [10, 34]],
+      bindingType: 'prototypeProperty',
+      type: 'primitive'
+    })
+  })
+
   it('handles the various visibility levels of APIs', function () {
     const donnaResult = runDonna(dedent`
       # Public: a thing

--- a/test/generate-test.js
+++ b/test/generate-test.js
@@ -134,6 +134,27 @@ describe('generate(code)', function () {
     assertMatchingObjects(result, donnaResult, [10, 2], [9, 2])
   })
 
+  it('handles section divider immediately followed by methods', function () {
+    const result = generate(dedent`
+      // A useful class
+      class Person {
+        /*
+        Section: construction
+        */
+
+        constructor (name) {
+          this.name = name
+        }
+      }
+    `)
+
+    assert.deepEqual(result.objects[2][2], {
+      type: 'comment',
+      doc: 'Section: construction',
+      range: [[2, 2], [4, 4]]
+    })
+  })
+
   it('handles top-level functions', function () {
     const donnaResult = runDonna(dedent`
       # A useful function


### PR DESCRIPTION
Now, if you provide documentation for instance properties assigned inside of a `constructor` function, `joanna` will generate documentation for these properties:

```js
class Person {
  constructor (params) {
    this.somePrivateState = new PrivateThing()

    // Public: the {String} name of the person.
    this.name = params.name || 'anonymous'

    // Public: the {Number} age of the person
    this.age = params.age || 0
  }
}
```

Refs https://github.com/atom/atom/issues/16487